### PR TITLE
Fixed cloning edid-decode behind a proxy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/enjoy-digital/litevideo.git
 [submodule "third_party/edid-decode"]
 	path = third_party/edid-decode
-	url = git://anongit.freedesktop.org/xorg/app/edid-decode
+	url = https://anongit.freedesktop.org/git/xorg/app/edid-decode
 [submodule "third_party/flash_proxies"]
        path = third_party/flash_proxies
        url = https://github.com/jordens/bscan_spi_bitstreams


### PR DESCRIPTION
git clone `git://anongit.freedesktop.org/xorg/app/edid-decode` does not work under proxy.

It gives the error :

``fatal: unable to connect to anongit.freedesktop.org:
anongit.freedesktop.org[0: 131.252.210.161]: errno=Connection refused
anongit.freedesktop.org[1: 2610:10:20:722:a800:ff:fe24:61cf]: errno=Network is unreachable``

[.... Given that my system proxy is set properly ....]

Instead replacing it with `git clone https://anongit.freedesktop.org/git/xorg/app/edid-decode` will help everywhere without disturbing the functionality.