### PR TITLE
scripts: Put CPU in the prompt.

### DIFF
--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -289,6 +289,11 @@ hdmi2usb_prompt() {
 	if [ ! -z "$TARGET" ]; then
 		P="$P T=$TARGET"
 	fi
+	# FIXME: Show CPU is not default, but default is hard coded to lm32 at
+	# the moment...
+	if [ "$CPU" != "lm32" ]; then
+		P="$P C=$CPU"
+	fi
 	if [ ! -z "$PROG" ]; then
 		P="$P P=$PROG"
 	fi


### PR DESCRIPTION
(Makes easier to tell you are building for or1k.)