### PR TITLE
Apply heartbeat to input FBs

### DIFF
--- a/firmware/framebuffer.h
+++ b/firmware/framebuffer.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Stefano Rivera <stefano@rivera.za.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+
+#ifndef __FRAMEBUFFER_H
+#define __FRAMEBUFFER_H
+
+#include <stdint.h>
+#include "generated/mem.h"
+
+// Largest frame size at 16bpp (ish)
+#define FRAMEBUFFER_SIZE (1920*1080*2)
+#define FRAMEBUFFER_COUNT 4
+#define FRAMEBUFFER_MASK (FRAMEBUFFER_COUNT - 1)
+typedef unsigned int fb_ptrdiff_t;
+// FIXME: typedef uint16_t framebuffer_t[FRAMEBUFFER_SIZE];
+
+inline unsigned int *fb_ptrdiff_to_main_ram(fb_ptrdiff_t p) {
+	return (unsigned int *)(MAIN_RAM_BASE + p);
+}
+
+#endif /* __FRAMEBUFFER_H */

--- a/firmware/hdmi_in0.c
+++ b/firmware/hdmi_in0.c
@@ -18,17 +18,13 @@
 int hdmi_in0_debug;
 int hdmi_in0_fb_index;
 
-#define FRAMEBUFFER_COUNT 4
-#define FRAMEBUFFER_MASK (FRAMEBUFFER_COUNT - 1)
-
 #define HDMI_IN0_FRAMEBUFFERS_BASE (0x00000000 + 0x100000)
-#define HDMI_IN0_FRAMEBUFFERS_SIZE (1920*1080*2)
 
 //#define CLEAN_COMMUTATION
 //#define DEBUG
 
-unsigned int hdmi_in0_framebuffer_base(char n) {
-	return HDMI_IN0_FRAMEBUFFERS_BASE + n*HDMI_IN0_FRAMEBUFFERS_SIZE;
+fb_ptrdiff_t hdmi_in0_framebuffer_base(char n) {
+	return HDMI_IN0_FRAMEBUFFERS_BASE + n * FRAMEBUFFER_SIZE;
 }
 
 static int hdmi_in0_fb_slot_indexes[2];
@@ -45,7 +41,7 @@ void hdmi_in0_isr(void)
 	unsigned int address_min, address_max;
 
 	address_min = HDMI_IN0_FRAMEBUFFERS_BASE & 0x0fffffff;
-	address_max = address_min + HDMI_IN0_FRAMEBUFFERS_SIZE*FRAMEBUFFER_COUNT;
+	address_max = address_min + FRAMEBUFFER_SIZE*FRAMEBUFFER_COUNT;
 	if((hdmi_in0_dma_slot0_status_read() == DVISAMPLER_SLOT_PENDING)
 		&& ((hdmi_in0_dma_slot0_address_read() < address_min) || (hdmi_in0_dma_slot0_address_read() > address_max)))
 		wprintf("dvisampler0: slot0: stray DMA\r\n");
@@ -163,7 +159,7 @@ void hdmi_in0_clear_framebuffers(void)
 	int i;
 	flush_l2_cache();
 	volatile unsigned int *framebuffer = (unsigned int *)(MAIN_RAM_BASE + HDMI_IN0_FRAMEBUFFERS_BASE);
-	for(i=0; i<(HDMI_IN0_FRAMEBUFFERS_SIZE*FRAMEBUFFER_COUNT)/4; i++) {
+	for(i=0; i<(FRAMEBUFFER_SIZE*FRAMEBUFFER_COUNT)/4; i++) {
 		framebuffer[i] = 0x80108010; /* black in YCbCr 4:2:2*/
 	}
 }

--- a/firmware/hdmi_in0.h
+++ b/firmware/hdmi_in0.h
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include "framebuffer.h"
 
 #ifndef __HDMI_IN0_H
 #define __HDMI_IN0_H
@@ -6,7 +7,7 @@
 extern int hdmi_in0_debug;
 extern int hdmi_in0_fb_index;
 
-unsigned int hdmi_in0_framebuffer_base(char n);
+fb_ptrdiff_t hdmi_in0_framebuffer_base(char n);
 
 void hdmi_in0_isr(void);
 void hdmi_in0_init_video(int hres, int vres);

--- a/firmware/hdmi_in1.c
+++ b/firmware/hdmi_in1.c
@@ -18,17 +18,13 @@
 int hdmi_in1_debug;
 int hdmi_in1_fb_index;
 
-#define FRAMEBUFFER_COUNT 4
-#define FRAMEBUFFER_MASK (FRAMEBUFFER_COUNT - 1)
-
 #define HDMI_IN1_FRAMEBUFFERS_BASE (0x01000000 + 0x100000)
-#define HDMI_IN1_FRAMEBUFFERS_SIZE (1920*1080*2)
 
 //#define CLEAN_COMMUTATION
 //#define DEBUG
 
-unsigned int hdmi_in1_framebuffer_base(char n) {
-	return HDMI_IN1_FRAMEBUFFERS_BASE + n*HDMI_IN1_FRAMEBUFFERS_SIZE;
+fb_ptrdiff_t hdmi_in1_framebuffer_base(char n) {
+	return HDMI_IN1_FRAMEBUFFERS_BASE + n*FRAMEBUFFER_SIZE;
 }
 
 static int hdmi_in1_fb_slot_indexes[2];
@@ -45,7 +41,7 @@ void hdmi_in1_isr(void)
 	unsigned int address_min, address_max;
 
 	address_min = HDMI_IN1_FRAMEBUFFERS_BASE & 0x0fffffff;
-	address_max = address_min + HDMI_IN1_FRAMEBUFFERS_SIZE*FRAMEBUFFER_COUNT;
+	address_max = address_min + FRAMEBUFFER_SIZE*FRAMEBUFFER_COUNT;
 	if((hdmi_in1_dma_slot0_status_read() == DVISAMPLER_SLOT_PENDING)
 		&& ((hdmi_in1_dma_slot0_address_read() < address_min) || (hdmi_in1_dma_slot0_address_read() > address_max)))
 		wprintf("dvisampler1: slot0: stray DMA\r\n");
@@ -163,7 +159,7 @@ void hdmi_in1_clear_framebuffers(void)
 	int i;
 	flush_l2_cache();
 	volatile unsigned int *framebuffer = (unsigned int *)(MAIN_RAM_BASE + HDMI_IN1_FRAMEBUFFERS_BASE);
-	for(i=0; i<(HDMI_IN1_FRAMEBUFFERS_SIZE*FRAMEBUFFER_COUNT)/4; i++) {
+	for(i=0; i<(FRAMEBUFFER_SIZE*FRAMEBUFFER_COUNT)/4; i++) {
 		framebuffer[i] = 0x80108010; /* black in YCbCr 4:2:2*/
 	}
 }

--- a/firmware/hdmi_in1.h
+++ b/firmware/hdmi_in1.h
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include "framebuffer.h"
 
 #ifndef __HDMI_IN1_H
 #define __HDMI_IN1_H
@@ -6,7 +7,7 @@
 extern int hdmi_in1_debug;
 extern int hdmi_in1_fb_index;
 
-unsigned int hdmi_in1_framebuffer_base(char n);
+fb_ptrdiff_t hdmi_in1_framebuffer_base(char n);
 
 void hdmi_in1_isr(void);
 void hdmi_in1_init_video(int hres, int vres);

--- a/firmware/heartbeat.h
+++ b/firmware/heartbeat.h
@@ -2,9 +2,10 @@
 #define __HEARTBEAT_H
 
 #include <stdbool.h>
+#include "framebuffer.h"
 
 void hb_status(bool val);
-void hb_service(int sink) ;
-void hb_fill(bool color_v, int sink);
+void hb_service(fb_ptrdiff_t fb_offset) ;
+void hb_fill(bool color_v, fb_ptrdiff_t fb_offset);
 
 #endif /* __HEARTBEAT_H */

--- a/firmware/processor.c
+++ b/firmware/processor.c
@@ -666,8 +666,6 @@ void processor_update(void)
 #endif
 	if(processor_hdmi_out0_source == VIDEO_IN_PATTERN)
 		hdmi_out0_core_initiator_base_write(pattern_framebuffer_base());
-
-	hb_service(VIDEO_OUT_HDMI_OUT0);
 #endif
 
 #ifdef CSR_HDMI_OUT1_BASE
@@ -682,8 +680,6 @@ void processor_update(void)
 #endif
 	if(processor_hdmi_out1_source == VIDEO_IN_PATTERN)
 		hdmi_out1_core_initiator_base_write(pattern_framebuffer_base());
-
-	hb_service(VIDEO_OUT_HDMI_OUT1);
 #endif
 
 
@@ -701,9 +697,15 @@ void processor_update(void)
 #endif
 	if(processor_encoder_source == VIDEO_IN_PATTERN)
 		encoder_reader_base_write(pattern_framebuffer_base());
-
-	hb_service(VIDEO_OUT_ENCODER);
 #endif
+
+#ifdef CSR_HDMI_IN0_BASE
+	hb_service(hdmi_in0_framebuffer_base(hdmi_in0_fb_index));
+#endif
+#ifdef CSR_HDMI_IN1_BASE
+	hb_service(hdmi_in1_framebuffer_base(hdmi_in1_fb_index));
+#endif
+	hb_service(pattern_framebuffer_base());
 }
 
 void processor_service(void)

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -157,7 +157,7 @@ echo ""
 echo "Initializing environment"
 echo "---------------------------------"
 # Install and setup conda for downloading packages
-export PATH=$CONDA_DIR/bin:$PATH
+export PATH=$CONDA_DIR/bin:$PATH:/sbin
 (
 	echo
 	echo "Installing conda (self contained Python environment with binary package support)"


### PR DESCRIPTION
The framebuffers belong to the sources not the sinks. So, simply write the heartbeat to the current framebuffer of each source.
    
This gets heartbeat working on non-pattern inputs again.

While we're here, set the right PATH for fxload on Debian, and remove an unnecessary volatile (part of #267).