### PR TITLE
The flashable image is now called image*.bin

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -175,7 +175,7 @@ function build() {
 
 		declare -a SAVE
 		declare -a SAVE
-		SAVE+="flash.bin" 				# Combined binary include gateware+bios+firmware
+		SAVE+="image*.bin" 				# Combined binary include gateware+bios+firmware
 		# Gateware output for using
 		SAVE+=("gateware/top.bit")			# Gateware in JTAG compatible format
 		SAVE+=("gateware/top.bin")			# Gateware in flashable format


### PR DESCRIPTION
It looks like our prebuilt builds have been missing the flashable image since 760?