### PR TITLE
Fix issues found while trying to run download-env

### DIFF
--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -67,7 +67,7 @@ if [ ! -f "$TARGET_QEMU_BUILD_DIR/Makefile" ]; then
 	mkdir -p $TARGET_QEMU_BUILD_DIR
 	(
 		cd $TARGET_QEMU_BUILD_DIR
-		$QEMU_SRC_DIR/configure \
+		CFLAGS="-Wno-error" $QEMU_SRC_DIR/configure \
 			--target-list=$QEMU_ARCH \
 			--python=/usr/bin/python2 \
 			--enable-fdt \

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -9,9 +9,9 @@ fi
 CALLED=$_
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] && SOURCED=1 || SOURCED=0
 
-SETUP_SRC=$(realpath ${BASH_SOURCE[0]})
-SETUP_DIR=$(dirname $SETUP_SRC)
-TOP_DIR=$(realpath $SETUP_DIR/..)
+SETUP_SRC="$(realpath ${BASH_SOURCE[0]})"
+SETUP_DIR="$(dirname "${SETUP_SRC}")"
+TOP_DIR="$(realpath "${SETUP_DIR}/..")"
 
 if [ $SOURCED = 1 ]; then
 	echo "You must run this script, rather then try to source it."
@@ -28,6 +28,20 @@ fi
 if [ ! -z "$SETTINGS_FILE" -o ! -z "$XILINX" ]; then
 	echo "You appear to have sourced the Xilinx ISE settings, these are incompatible with setting up."
 	echo "Please exit this terminal and run again from a clean shell."
+	exit 1
+fi
+
+# Conda does not support ' ' in the path (it bails early).
+if echo "${SETUP_DIR}" | grep -q ' '; then
+	echo "You appear to have whitespace characters in the path to this script."
+	echo "Please move this repository to another path that does not contain whitespace."
+	exit 1
+fi
+
+# Conda does not support ':' in the path (it fails to install python).
+if echo "${SETUP_DIR}" | grep -q ':'; then
+	echo "You appear to have ':' characters in the path to this script."
+	echo "Please move this repository to another path that does not contain this character."
 	exit 1
 fi
 

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -164,11 +164,15 @@ export PATH=$CONDA_DIR/bin:$PATH:/sbin
 (
 	echo
 	echo "Installing conda (self contained Python environment with binary package support)"
-	if [ ! -d $CONDA_DIR ]; then
+	if [[ ! -e $CONDA_DIR/bin/conda ]]; then
 		cd $BUILD_DIR
-		wget --no-verbose -c https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+		# FIXME: Get the miniconda people to add a "self check" mode
+		wget --no-verbose --continue https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 		chmod a+x Miniconda3-latest-Linux-x86_64.sh
-		./Miniconda3-latest-Linux-x86_64.sh -p $CONDA_DIR -b
+		# -p to specify the install location
+		# -b to enable batch mode (no prompts)
+		# -f to not return an error if the location specified by -p already exists
+		./Miniconda3-latest-Linux-x86_64.sh -p $CONDA_DIR -b -f
 		conda config --set always_yes yes --set changeps1 no
 		conda update -q conda
 	fi

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -9,9 +9,9 @@ fi
 CALLED=$_
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] && SOURCED=1 || SOURCED=0
 
-SETUP_SRC=$(realpath ${BASH_SOURCE[0]})
-SETUP_DIR=$(dirname $SETUP_SRC)
-TOP_DIR=$(realpath $SETUP_DIR/..)
+SETUP_SRC="$(realpath ${BASH_SOURCE[0]})"
+SETUP_DIR="$(dirname "${SETUP_SRC}")"
+TOP_DIR="$(realpath "${SETUP_DIR}/..")"
 LIKELY_XILINX_LICENSE_LOCATION="$HOME/.Xilinx/Xilinx.lic"
 
 if [ $SOURCED = 0 ]; then
@@ -29,6 +29,20 @@ if [ ! -z "$SETTINGS_FILE" -o ! -z "$XILINX" ]; then
 	echo "You appear to have sourced the Xilinx ISE settings, these are incompatible with building."
 	echo "Please exit this terminal and run again from a clean shell."
 	return 1
+fi
+
+# Conda does not support ' ' in the path (it bails early).
+if echo "${SETUP_DIR}" | grep -q ' '; then
+	echo "You appear to have whitespace characters in the path to this script."
+	echo "Please move this repository to another path that does not contain whitespace."
+	exit 1
+fi
+
+# Conda does not support ':' in the path (it fails to install python).
+if echo "${SETUP_DIR}" | grep -q ':'; then
+	echo "You appear to have ':' characters in the path to this script."
+	echo "Please move this repository to another path that does not contain this character."
+	exit 1
 fi
 
 # Check ixo-usb-jtag *isn't* install


### PR DESCRIPTION
Fix some of the issues I found while trying to run the linux image on qemu.

Specifically:
 - Disable warnings as errors when compiling qemu
 - Complain to the user if the path to the repository is known to break (contains either whitespace or ':')
 - Make the download-env script continue to attempt to install conda if a previous attempt failed