### PR TITLE
Calculate a FRAMEBUFFERS_BASE for hdmi_inX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 *.pyc
 *.egg-info
 *.vcd
+firmware/hdmi_in[1-9].[ch]
 outgoing
 build
 *~

--- a/firmware/framebuffer.h
+++ b/firmware/framebuffer.h
@@ -25,17 +25,17 @@
  * Each input then has 3 frame buffers spaced like this;
  *  // HDMI Input 0
  *  0x01000000 - HDMI Input 0 - Frame Buffer n
- *  0x01000000 - HDMI Input 0 - Frame Buffer n+1
- *  0x01000000 - HDMI Input 0 - Frame Buffer n+2
+ *  0x01040000 - HDMI Input 0 - Frame Buffer n+1
+ *  0x01080000 - HDMI Input 0 - Frame Buffer n+2
  *  // HDMI Input 1
  *  0x02000000 - HDMI Input 1 - Frame Buffer n
- *  0x02000000 - HDMI Input 1 - Frame Buffer n+1
- *  0x02000000 - HDMI Input 1 - Frame Buffer n+2
+ *  0x02040000 - HDMI Input 1 - Frame Buffer n+1
+ *  0x02080000 - HDMI Input 1 - Frame Buffer n+2
  *  ...
  *  // HDMI Input x
  *  0x0x000000 - HDMI Input x - Frame Buffer n
- *  0x0x000000 - HDMI Input x - Frame Buffer n+1
- *  0x0x000000 - HDMI Input x - Frame Buffer n+2
+ *  0x0x040000 - HDMI Input x - Frame Buffer n+1
+ *  0x0x080000 - HDMI Input x - Frame Buffer n+2
  *
  */
 #define FRAMEBUFFER_OFFSET		0x01000000

--- a/firmware/framebuffer.h
+++ b/firmware/framebuffer.h
@@ -17,10 +17,47 @@
 #include <stdint.h>
 #include "generated/mem.h"
 
+/**
+ * Frame buffers must be aligned to XXX boundary.
+ *
+ * 0x0100000 - Pattern Buffer - Frame Buffer n
+ *
+ * Each input then has 3 frame buffers spaced like this;
+ *  // HDMI Input 0
+ *  0x01000000 - HDMI Input 0 - Frame Buffer n
+ *  0x01000000 - HDMI Input 0 - Frame Buffer n+1
+ *  0x01000000 - HDMI Input 0 - Frame Buffer n+2
+ *  // HDMI Input 1
+ *  0x02000000 - HDMI Input 1 - Frame Buffer n
+ *  0x02000000 - HDMI Input 1 - Frame Buffer n+1
+ *  0x02000000 - HDMI Input 1 - Frame Buffer n+2
+ *  ...
+ *  // HDMI Input x
+ *  0x0x000000 - HDMI Input x - Frame Buffer n
+ *  0x0x000000 - HDMI Input x - Frame Buffer n+1
+ *  0x0x000000 - HDMI Input x - Frame Buffer n+2
+ *
+ */
+#define FRAMEBUFFER_OFFSET		0x01000000
+#define FRAMEBUFFER_PATTERNS		1
+
+#define FRAMEBUFFER_PIXELS_X		1920	// pixels
+#define FRAMEBUFFER_PIXELS_Y		1080	// pixels
+#define FRAMEBUFFER_PIXELS_BYTES	2	// bytes
+
+#define FRAMEBUFFER_BASE(x)			(x*FRAMEBUFFER_OFFSET)
+#define FRAMEBUFFER_BASE_PATTERN		FRAMEBUFFER_BASE(0)
+#define FRAMEBUFFER_BASE_HDMI_INPUT(x)		FRAMEBUFFER_BASE(x+FRAMEBUFFER_PATTERNS)
+
 // Largest frame size at 16bpp (ish)
-#define FRAMEBUFFER_SIZE (1920*1080*2)
-#define FRAMEBUFFER_COUNT 4
-#define FRAMEBUFFER_MASK (FRAMEBUFFER_COUNT - 1)
+#define FRAMEBUFFER_SIZE		0x400000 // bytes
+#if (FRAMEBUFFER_PIXELS_X*FRAMEBUFFER_PIXELS_Y*FRAMEBUFFER_PIXELS_BYTES) > FRAMEBUFFER_SIZE
+#error "Number of pixels don't fit in frame buffer"
+#endif
+
+#define FRAMEBUFFER_COUNT 		4			// Must be a multiple of 2
+#define FRAMEBUFFER_MASK 		(FRAMEBUFFER_COUNT - 1)
+
 typedef unsigned int fb_ptrdiff_t;
 // FIXME: typedef uint16_t framebuffer_t[FRAMEBUFFER_SIZE];
 

--- a/firmware/hdmi_in.sh
+++ b/firmware/hdmi_in.sh
@@ -29,7 +29,7 @@ TMPFILE_H=$(tempfile -s .h | mktemp --suffix=.h)
 TMPFILE_C=$(tempfile -s .c | mktemp --suffix=.c)
 
 cat $FIRMWARE_DIR/hdmi_in0.h | sed \
-	-e"s/IN0_INDEX 0/IN${X}_INDEX $X/g" \
+	-e"s/IN0_INDEX\([^0-9]\+\)0/IN${X}_INDEX\1$X/g" \
 	-e"s/IN0/IN$X/g" \
 	-e"s/in0/in$X/g" \
 	> $TMPFILE_H

--- a/firmware/hdmi_in.sh
+++ b/firmware/hdmi_in.sh
@@ -29,6 +29,7 @@ TMPFILE_H=$(tempfile -s .h | mktemp --suffix=.h)
 TMPFILE_C=$(tempfile -s .c | mktemp --suffix=.c)
 
 cat $FIRMWARE_DIR/hdmi_in0.h | sed \
+	-e"s/IN0_INDEX 0/IN${X}_INDEX $X/g" \
 	-e"s/IN0/IN$X/g" \
 	-e"s/in0/in$X/g" \
 	> $TMPFILE_H

--- a/firmware/hdmi_in0.c
+++ b/firmware/hdmi_in0.c
@@ -19,8 +19,6 @@
 int hdmi_in0_debug;
 int hdmi_in0_fb_index;
 
-#define HDMI_IN0_FRAMEBUFFERS_BASE (0x00000000 + 0x100000)
-
 //#define CLEAN_COMMUTATION
 //#define DEBUG
 

--- a/firmware/hdmi_in0.h
+++ b/firmware/hdmi_in0.h
@@ -4,7 +4,8 @@
 #ifndef __HDMI_IN0_H
 #define __HDMI_IN0_H
 
-#define HDMI_IN0_FRAMEBUFFERS_BASE (0x01000000 + 0x100000)
+#define HDMI_IN0_INDEX 0
+#define HDMI_IN0_FRAMEBUFFERS_BASE ((HDMI_IN0_INDEX + 1) * 0x01000000 + 0x100000)
 
 extern int hdmi_in0_debug;
 extern int hdmi_in0_fb_index;

--- a/firmware/hdmi_in0.h
+++ b/firmware/hdmi_in0.h
@@ -4,6 +4,8 @@
 #ifndef __HDMI_IN0_H
 #define __HDMI_IN0_H
 
+#define HDMI_IN0_FRAMEBUFFERS_BASE (0x01000000 + 0x100000)
+
 extern int hdmi_in0_debug;
 extern int hdmi_in0_fb_index;
 

--- a/firmware/hdmi_in0.h
+++ b/firmware/hdmi_in0.h
@@ -4,8 +4,12 @@
 #ifndef __HDMI_IN0_H
 #define __HDMI_IN0_H
 
-#define HDMI_IN0_INDEX 0
-#define HDMI_IN0_FRAMEBUFFERS_BASE ((HDMI_IN0_INDEX + 1) * 0x01000000 + 0x100000)
+#ifdef HDMI_IN0_INDEX
+#error "HDMI_IN0_INDEX already defined!"
+#endif
+
+#define HDMI_IN0_INDEX 			0
+#define HDMI_IN0_FRAMEBUFFERS_BASE 	FRAMEBUFFER_BASE_HDMI_INPUT(HDMI_IN0_INDEX)
 
 extern int hdmi_in0_debug;
 extern int hdmi_in0_fb_index;

--- a/firmware/pattern.c
+++ b/firmware/pattern.c
@@ -12,10 +12,8 @@
 #include "uptime.h"
 #include "version_data.h"
 
-#define PATTERN_FRAMEBUFFER_BASE 0x00000000 + 0x100000
-
 unsigned int pattern_framebuffer_base(void) {
-	return PATTERN_FRAMEBUFFER_BASE;
+	return FRAMEBUFFER_BASE_PATTERN;
 }
 
 static const unsigned int color_bar[8] = {
@@ -136,7 +134,7 @@ static int inc_color(int color) {
 static void pattern_draw_text_color(int x, int y, char *ptr, long background_color, long text_color) {
 	int i, j, k;
 	int adr;
-	volatile unsigned int *framebuffer = (unsigned int *)(MAIN_RAM_BASE + PATTERN_FRAMEBUFFER_BASE);
+	volatile unsigned int *framebuffer = (unsigned int *)(MAIN_RAM_BASE + pattern_framebuffer_base());
 	for(i=0; ptr[i] != '\0'; i++) {
 		for(j=-1; j<8; j++) {
 			for(k=-1; k<6; k++) {
@@ -159,7 +157,7 @@ static void pattern_draw_text(int x, int y, char *ptr) {
 
 void pattern_next(void) {
 	pattern++;
-	pattern = pattern % MAX_PATTERN;
+	pattern = pattern % PATTERN_MAX;
 	pattern_fill_framebuffer(processor_h_active, processor_v_active);
 }
 
@@ -170,8 +168,8 @@ void pattern_fill_framebuffer(int h_active, int w_active)
 	int color;
 	flush_l2_cache();
 	color = -1;
-	volatile unsigned int *framebuffer = (unsigned int *)(MAIN_RAM_BASE + PATTERN_FRAMEBUFFER_BASE);
-	if(pattern == COLOR_BAR_PATTERN) {
+	volatile unsigned int *framebuffer = (unsigned int *)(MAIN_RAM_BASE + pattern_framebuffer_base());
+	if(pattern == PATTERN_COLOR_BARS) {
 		/* color bar pattern */
 		for(i=0; i<h_active*w_active*2/4; i++) {
 			if(i%(h_active/16) == 0)

--- a/firmware/pattern.c
+++ b/firmware/pattern.c
@@ -12,7 +12,7 @@
 #include "uptime.h"
 #include "version_data.h"
 
-#define PATTERN_FRAMEBUFFER_BASE 0x02000000 + 0x100000
+#define PATTERN_FRAMEBUFFER_BASE 0x00000000 + 0x100000
 
 unsigned int pattern_framebuffer_base(void) {
 	return PATTERN_FRAMEBUFFER_BASE;

--- a/firmware/pattern.h
+++ b/firmware/pattern.h
@@ -1,6 +1,8 @@
 #ifndef __PATTERN_H
 #define __PATTERN_H
 
+#include "framebuffer.h"
+
 /* Colors in YCBCR422 format (see pattern.py) */
 #define YCBCR422_WHITE  0x80ff80ff
 #define YCBCR422_YELLOW 0x00e194e1
@@ -23,11 +25,11 @@
 
 unsigned int pattern_framebuffer_base(void);
 
-int pattern;
-
-#define COLOR_BAR_PATTERN 0
-#define VERTICAL_BLACK_WHITE_LINES_PATTERN 1
-#define MAX_PATTERN 2
+enum {
+	PATTERN_COLOR_BARS = 0,
+	PATTERN_VERTICAL_BLACK_WHITE_LINES = 1,
+	PATTERN_MAX,
+} pattern;
 
 void pattern_fill_framebuffer(int h_active, int m_active);
 void pattern_service(void);

--- a/firmware/processor.c
+++ b/firmware/processor.c
@@ -586,7 +586,7 @@ void processor_init(int sec_mode)
 		encoder_enable(0);
 		encoder_target_fps = 30;
 #endif
-	pattern = COLOR_BAR_PATTERN;
+	pattern = PATTERN_COLOR_BARS;
 	processor_secondary_mode = sec_mode;
 }
 


### PR DESCRIPTION
We accidentally started using the same framebuffers for all inputs in 92eb6f9a1333d8c9ca83a60f54f40fa15c6aaa58