### PR TITLE
Trying to fix failing builds on Travis.

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -301,7 +301,10 @@ else
 	echo "- Uploading built files to github.com/$PREBUILT_REPO_OWNER/$PREBUILT_REPO"
 	echo "---------------------------------------------"
 	export PREBUILT_DIR="/tmp/HDMI2USB-firmware-prebuilt"
-	git clone https://$GH_TOKEN@github.com/$PREBUILT_REPO_OWNER/${PREBUILT_REPO}.git $PREBUILT_DIR
+	git clone \
+		--depth 10 \
+		--branch master \
+		https://$GH_TOKEN@github.com/$PREBUILT_REPO_OWNER/${PREBUILT_REPO}.git $PREBUILT_DIR
 	echo "============================================="
 fi
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -52,7 +52,14 @@ function build() {
 	export TARGET_BUILD_DIR=$PWD/build/${PLATFORM}_${TARGET}_${CPU}
 	export LOGFILE=$TARGET_BUILD_DIR/output.$(date +%Y%m%d-%H%M%S).log
 	echo "Using logfile $LOGFILE"
-
+	echo ""
+	echo ""
+	echo ""
+	echo "- Disk space free (before build)"
+	echo "---------------------------------------------"
+	df -h
+	DF_BEFORE_BUILD="$(($(stat -f --format="%a*%S" .)))"
+	echo "============================================="
 	echo ""
 	echo ""
 	echo ""
@@ -234,6 +241,17 @@ function build() {
 		)
 		echo "============================================="
 	fi
+
+	echo ""
+	echo ""
+	echo ""
+	echo "- Disk space free (after build)"
+	echo "---------------------------------------------"
+	df -h
+	echo ""
+	DF_AFTER_BUILD="$(($(stat -f --format="%a*%S" .)))"
+	awk "BEGIN {printf \"Build is using %.2f megabytes\n\",($DF_BEFORE_BUILD-$DF_AFTER_BUILD)/1024/1024}"
+	echo "============================================="
 
 	if [ ! -z "$CLEAN_CHECK" ]; then
 		echo ""

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -8,6 +8,7 @@ echo ""
 echo "- Disk space free (initial)"
 echo "---------------------------------------------"
 df -h
+echo ""
 DF_INITIAL="$(($(stat -f --format="%a*%S" .)))"
 DF_LAST=$DF_INITIAL
 
@@ -102,14 +103,27 @@ echo ""
 echo "- Disk space free (after fixing git)"
 echo "---------------------------------------------"
 df -h
+echo ""
 DF_AFTER_GIT="$(($(stat -f --format="%a*%S" .)))"
-awk "BEGIN {printf \"Git is using %.2f megabytes\n\",($DF_AFTER_GIT-$DF_LAST)/1024/1024}"
+awk "BEGIN {printf \"Git is using %.2f megabytes\n\",($DF_LAST-$DF_AFTER_GIT)/1024/1024}"
 DF_LAST="$DF_AFTER_GIT"
 
+echo ""
+echo "============================================="
+echo ""
+echo ""
 # Run the script once to check it works
 time scripts/download-env.sh
+echo ""
+echo ""
+echo "============================================="
+echo ""
+echo ""
 # Run the script again to check it doesn't break things
 time scripts/download-env.sh
+echo ""
+echo ""
+echo "============================================="
 
 echo ""
 echo ""
@@ -117,10 +131,15 @@ echo ""
 echo "- Disk space free (after downloading environment)"
 echo "---------------------------------------------"
 df -h
+echo ""
 DF_AFTER_DOWNLOAD="$(($(stat -f --format="%a*%S" .)))"
-awk "BEGIN {printf \"Environment is using %.2f megabytes\n\",($DF_AFTER_DOWNLOAD-$DF_LAST)/1024/1024}"
+awk "BEGIN {printf \"Environment is using %.2f megabytes\n\",($DF_LAST-$DF_AFTER_DOWNLOAD)/1024/1024}"
 DF_LAST="$DF_AFTER_DOWNLOAD"
 
+echo "============================================="
+echo "============================================="
+echo ""
+echo ""
 set +x
 set +e
 source scripts/enter-env.sh

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -105,8 +105,8 @@ echo "- Disk space free (after fixing git)"
 echo "---------------------------------------------"
 df -h
 DF_AFTER_GIT="$(($(stat -f --format="%a*%S" .)))"
-DF_LAST="$DF_AFTER_GIT"
 awk "BEGIN {printf \"Git is using %.2f megabytes\n\",($DF_AFTER_GIT-$DF_LAST)/1024/1024}"
+DF_LAST="$DF_AFTER_GIT"
 
 # Run the script once to check it works
 time scripts/download-env.sh
@@ -120,8 +120,8 @@ echo "- Disk space free (after downloading environment)"
 echo "---------------------------------------------"
 df -h
 DF_AFTER_DOWNLOAD="$(($(stat -f --format="%a*%S" .)))"
-DF_LAST="$DF_AFTER_DOWNLOAD"
 awk "BEGIN {printf \"Environment is using %.2f megabytes\n\",($DF_AFTER_DOWNLOAD-$DF_LAST)/1024/1024}"
+DF_LAST="$DF_AFTER_DOWNLOAD"
 
 set +x
 set +e

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -5,6 +5,15 @@ set -e
 echo ""
 echo ""
 echo ""
+echo "- Disk space free (initial)"
+echo "---------------------------------------------"
+df -h
+DF_INITIAL="$(($(stat -f --format="%a*%S" .)))"
+DF_LAST=$DF_INITIAL
+
+echo ""
+echo ""
+echo ""
 echo "- Fetching non shallow to get git version"
 echo "---------------------------------------------"
 git fetch origin --unshallow && git fetch origin --tags
@@ -89,10 +98,30 @@ GIT_REVISION=$(git describe)
 
 set -x
 
+echo ""
+echo ""
+echo ""
+echo "- Disk space free (after fixing git)"
+echo "---------------------------------------------"
+df -h
+DF_AFTER_GIT="$(($(stat -f --format="%a*%S" .)))"
+DF_LAST="$DF_AFTER_GIT"
+awk "BEGIN {printf \"Git is using %.2f megabytes\n\",($DF_AFTER_GIT-$DF_LAST)/1024/1024}"
+
 # Run the script once to check it works
 time scripts/download-env.sh
 # Run the script again to check it doesn't break things
 time scripts/download-env.sh
+
+echo ""
+echo ""
+echo ""
+echo "- Disk space free (after downloading environment)"
+echo "---------------------------------------------"
+df -h
+DF_AFTER_DOWNLOAD="$(($(stat -f --format="%a*%S" .)))"
+DF_LAST="$DF_AFTER_DOWNLOAD"
+awk "BEGIN {printf \"Environment is using %.2f megabytes\n\",($DF_AFTER_DOWNLOAD-$DF_LAST)/1024/1024}"
 
 set +x
 set +e

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -96,8 +96,6 @@ git describe
 echo "============================================="
 GIT_REVISION=$(git describe)
 
-set -x
-
 echo ""
 echo ""
 echo ""

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -86,6 +86,9 @@ if [ ! -z "$XILINX_PASSPHRASE" ]; then
 			cat $XILINX_PASSPHRASE_FILE | gpg --batch --passphrase-fd 0 ${XILINX_TAR_FILE}.gpg
 			tar -xjf $XILINX_TAR_FILE
 
+			# Remove the tar file to free up space.
+			rm ${XILINX_TAR_FILE}*
+
 			# FIXME: Hacks to try and make Vivado work.
 			mkdir -p $XILINX_DIR/opt/Xilinx/Vivado/2017.3/scripts/rt/data/svlog/sdbs
 			mkdir -p $XILINX_DIR/opt/Xilinx/Vivado/2017.3/tps/lnx64/jre

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -84,7 +84,7 @@ if [ ! -z "$XILINX_PASSPHRASE" ]; then
 			# This setup was taken from https://github.com/m-labs/artiq/blob/master/.travis/get-xilinx.sh
 			wget --no-verbose -c http://xilinx.timvideos.us/${XILINX_TAR_FILE}.gpg
 			cat $XILINX_PASSPHRASE_FILE | gpg --batch --passphrase-fd 0 ${XILINX_TAR_FILE}.gpg
-			tar -xjvf $XILINX_TAR_FILE
+			tar -xjf $XILINX_TAR_FILE
 
 			# FIXME: Hacks to try and make Vivado work.
 			mkdir -p $XILINX_DIR/opt/Xilinx/Vivado/2017.3/scripts/rt/data/svlog/sdbs


### PR DESCRIPTION
Current theory is that the machines are running out of disk, see https://travis-ci.org/timvideos/HDMI2USB-litex-firmware/jobs/297702973
```
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/opsis/hdmi2usb/sha256sum.txt
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/opsis/video/opsis_video-customvideomixersoc-opsis.bin
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/opsis/video/opsis_video-customvideomixersoc-opsis.bit
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/opsis/video/output.log
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/opsis/video/sha256sum.txt
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/pipistrello/base/output.log
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/pipistrello/base/pipistrello_base-videomixersoc-pipistrello.bin
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/pipistrello/base/pipistrello_base-videomixersoc-pipistrello.bit
error: unable to write file archive/pycon2016/v0.0.2-82-g6bdf86a/pipistrello/base/sha256sum.txt
error: unable to write file archive/pycon2016/v0.0.2-84-gdb8aa7f/atlys/base/atlys_base-basesoc-atlys.bin
error: unable to write file archive/pycon2016/v0.0.2-84-gdb8aa7f/atlys/base/atlys_base-basesoc-atlys.bit
error: unable to create file archive/pycon2016/v0.0.2-84-gdb8aa7f/atlys/base/output.log: No space left on device
error: unable to create file archive/pycon2016/v0.0.2-84-gdb8aa7f/atlys/base/sha256sum.txt: No space left on device
fatal: cannot create directory at 'archive/pycon2016/v0.0.2-84-gdb8aa7f/atlys/hdmi2eth': No space left on device
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry the checkout with 'git checkout -f HEAD'
```

This change improves the disk usage situation and echoes the output more.
