### PR TITLE
Better parallel make support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ env:
   global:
    - HDMI2USB_UDEV_IGNORE=1
    - CLEAN_CHECK=1
+   # Travis reports incorrect the hosts number of processors, override to 2
+   # cores.
+   - JOBS=2
 
 install:
  - export CPU="$C"

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ build/cache.mk: targets/*/*.py scripts/makefile-cache.sh
 
 TARGETS=$(TARGETS_$(PLATFORM))
 
-
 # Initialize submodules automatically
 third_party/%/.git: .gitmodules
 	git submodule sync --recursive -- $$(dirname $@)
@@ -201,12 +200,13 @@ firmware-connect: firmware-connect-$(PLATFORM)
 firmware-clear: firmware-clear-$(PLATFORM)
 	@true
 
-.PHONY: firmware-load-$(PLATFORM) firmware-flash-$(PLATFORM) firmware-connect-$(PLATFORM) firmware-clear-$(PLATFORM)
-
 firmware-clean:
 	rm -rf $(TARGET_BUILD_DIR)/software
 
+.PHONY: firmware-load-$(PLATFORM) firmware-flash-$(PLATFORM) firmware-flash-py firmware-connect-$(PLATFORM) firmware-clear-$(PLATFORM)
+.NOTPARALLEL: firmware-load-$(PLATFORM) firmware-flash-$(PLATFORM) firmware-flash-py firmware-connect-$(PLATFORM) firmware-clear-$(PLATFORM)
 .PHONY: firmware-cmd $(FIRMWARE_FILEBASE).bin firmware firmware-load firmware-flash firmware-connect firmware-clean
+.NOTPARALLEL: firmware-cmd firmware-load firmware-flash firmware-connect
 
 $(BIOS_FILE): firmware-cmd
 	@true
@@ -367,8 +367,8 @@ clean:
 dist-clean:
 	rm -rf build
 
-.PHONY: flash help clean dist-clean help-$(PLATFORM) reset reset-$(PLATFORM)
-.NOTPARALLEL: flash help help-$(PLATFORM) reset reset-$(PLATFORM)
+.PHONY: flash env info prompt help clean dist-clean help-$(PLATFORM) reset reset-$(PLATFORM)
+.NOTPARALLEL: flash env prompt info help help-$(PLATFORM) reset reset-$(PLATFORM)
 
 # Tests
 # --------------------------------------
@@ -383,3 +383,4 @@ test:
 	true
 
 .PHONY: test test-edid
+.NOTPARALLEL: test test-edid

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ export CLANG
 JOBS ?= $(shell nproc)
 JOBS ?= 2
 
+ifeq ($(shell [ $(JOBS) -gt 1 ] && echo true),true)
+    export MAKEFLAGS="-j $(JOBS) -l $(JOBS)"
+endif
+
 ifeq ($(PLATFORM_EXPANSION),)
 FULL_PLATFORM = $(PLATFORM)
 else

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ image-flash-py: image
 	$(PYTHON) flash.py --mode=image
 
 .PHONY: image image-load image-flash image-flash-py image-flash-$(PLATFORM) image-load-$(PLATFORM)
+.NOTPARALLEL: image-load image-flash image-flash-py image-flash-$(PLATFORM) image-load-$(PLATFORM)
 
 # Gateware - the stuff which configures the FPGA.
 # --------------------------------------
@@ -163,6 +164,7 @@ gateware-clean:
 	rm -rf $(TARGET_BUILD_DIR)/gateware
 
 .PHONY: gateware gateware-load gateware-flash gateware-flash-py gateware-clean gateware-load-$(PLATFORM) gateware-flash-$(PLATFORM)
+.NOTPARALLEL: gateware-load gateware-flash gateware-flash-py gateware-flash-$(PLATFORM) gateware-load-$(PLATFORM)
 
 # Firmware - the stuff which runs in the soft CPU inside the FPGA.
 # --------------------------------------
@@ -216,6 +218,7 @@ bios-flash: $(BIOS_FILE) bios-flash-$(PLATFORM)
 	@true
 
 .PHONY: $(FIRMWARE_FILE) bios bios-flash bios-flash-$(PLATFORM)
+.NOTPARALLEL: bios-flash bios-flash-$(PLATFORM)
 
 
 # TFTP booting stuff
@@ -244,6 +247,7 @@ tftpd_start:
 	fi
 
 .PHONY: tftp tftpd_stop tftpd_start
+.NOTPARALLEL: tftp tftpd_stop tftpd_start
 
 # Extra targets
 # --------------------------------------
@@ -364,6 +368,7 @@ dist-clean:
 	rm -rf build
 
 .PHONY: flash help clean dist-clean help-$(PLATFORM) reset reset-$(PLATFORM)
+.NOTPARALLEL: flash help help-$(PLATFORM) reset reset-$(PLATFORM)
 
 # Tests
 # --------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ FIRMWARE ?= firmware
 CLANG = 0
 export CLANG
 
+JOBS ?= $(shell nproc)
+JOBS ?= 2
+
 ifeq ($(PLATFORM_EXPANSION),)
 FULL_PLATFORM = $(PLATFORM)
 else
@@ -264,6 +267,7 @@ env:
 	@# Hardcoded values
 	@echo "export CLANG=$(CLANG)"
 	@echo "export PYTHONHASHSEED=$(PYTHONHASHSEED)"
+	@echo "export JOBS=$(JOBS)"
 	@# Files
 	@echo "export IMAGE_FILE='$(IMAGE_FILE)'"
 	@echo "export GATEWARE_FILEBASE='$(GATEWARE_FILEBASE)'"

--- a/scripts/build-micropython.sh
+++ b/scripts/build-micropython.sh
@@ -71,7 +71,7 @@ export BUILDINC_DIRECTORY="$(realpath $TARGET_BUILD_DIR/software/include)"
 export BUILD="$(realpath $TARGET_MPY_BUILD_DIR)"
 OLD_DIR=$PWD
 cd $TARGET_MPY_BUILD_DIR
-make V=1 -C $(realpath ../../../../third_party/micropython/litex/)
+make V=1 -C $(realpath ../../../../third_party/micropython/litex/) -j$JOBS
 cd $OLD_DIR
 
 # Generate a firmware image suitable for flashing.

--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -83,7 +83,7 @@ fi
 
 OLD_DIR=$PWD
 cd $TARGET_QEMU_BUILD_DIR
-make -j8
+make -j$JOBS
 cd $OLD_DIR
 
 # Need the .fbi for mkimage below...


### PR DESCRIPTION
This should make everything work if `-j` is given to make. It should also mean that the correct number of processors are used in the `./scripts/build-xxx.sh` files.