### PR TITLE
Make conda not use a user's home directory.

### DIFF
--- a/.travis/prevent-condarc.sh
+++ b/.travis/prevent-condarc.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p ~/.conda
+chmod 0000 ~/.conda

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+./.travis/prevent-condarc.sh
+
 ./.travis/fixup-git.sh
 
 function setup() {

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -184,10 +184,10 @@ export PATH=$CONDA_DIR/bin:$PATH:/sbin
 		# -b to enable batch mode (no prompts)
 		# -f to not return an error if the location specified by -p already exists
 		./Miniconda3-latest-Linux-x86_64.sh -p $CONDA_DIR -b -f
-		conda config --set always_yes yes --set changeps1 no
+		conda config --system --set always_yes yes --set changeps1 no
 		conda update -q conda
 	fi
-	conda config --add channels timvideos
+	conda config --system --add channels timvideos
 )
 
 eval $(cd $TOP_DIR; export HDMI2USB_ENV=1; make env || return 1) || exit 1

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -184,7 +184,10 @@ export PATH=$CONDA_DIR/bin:$PATH:/sbin
 		# -b to enable batch mode (no prompts)
 		# -f to not return an error if the location specified by -p already exists
 		./Miniconda3-latest-Linux-x86_64.sh -p $CONDA_DIR -b -f
-		conda config --system --set always_yes yes --set changeps1 no
+		conda config --system --set always_yes yes
+		conda config --system --set changeps1 no
+		conda config --system --add envs_dirs $CONDA_DIR/envs
+		conda config --system --add pkgs_dirs $CONDA_DIR/pkgs
 		conda update -q conda
 	fi
 	conda config --system --add channels timvideos


### PR DESCRIPTION
Conda should be self contained in the `build/conda` directory. Add travis checks for it.