### PR TITLE
Don't do mdio_dump in mdio_status

### DIFF
--- a/firmware/mdio.c
+++ b/firmware/mdio.c
@@ -93,7 +93,6 @@ void mdio_dump(void) {
 
 int mdio_status(void) {
 	int status;
-	mdio_dump();
 
 	status = mdio_read(0, 17);
 


### PR DESCRIPTION
We have a separate command for that.