### PR TITLE
Add version to help prompt

### DIFF
--- a/firmware/ci.c
+++ b/firmware/ci.c
@@ -191,6 +191,7 @@ static void ci_help(void)
 	wputs("mdio_status - show mdio status");
 #endif
 	wputs("pattern (p) - select next pattern");
+	wputs("version - show firmware version");
 	wputs("");
 	help_status();
 	wputs("");


### PR DESCRIPTION
the `help` command currently does not show the `version` option. This adds it to the initial section