### PR TITLE
cmod_a7: Fixing default target.

### DIFF
--- a/targets/cmod_a7/Makefile.mk
+++ b/targets/cmod_a7/Makefile.mk
@@ -5,7 +5,7 @@ ifneq ($(PLATFORM),cmod_a7)
 endif
 
 # Settings
-DEFAULT_TARGET = net
+DEFAULT_TARGET = base
 TARGET ?= $(DEFAULT_TARGET)
 
 PROG_PORT ?= /dev/ttyUSB0


### PR DESCRIPTION
Changed default target from `net` to `base`.