### PR TITLE
travis: Adding update as travis suggested.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler:
 sudo: false
 addons:
   apt:
+    update: true
     packages:
     - build-essential
     - fxload


### PR DESCRIPTION
```
Running apt-get update by default has been disabled.
You can opt into running apt-get update by setting this in your .travis.yml file:
  addons:
    apt:
      update: true
```