### PR TITLE
Update getting-started .md

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -371,7 +371,6 @@ changing resolution:
 ```
 hdmi2usb-mode-switch --mode=serial
 ```
-
 ```
 make firmware-connect
 ```

--- a/getting-started.md
+++ b/getting-started.md
@@ -369,6 +369,10 @@ MDIO mode: 1000Mbps / link: down
 Connect to lm32 softcore to send direct commands to the HDMI2USB such as
 changing resolution:
 ```
+hdmi2usb-mode-switch --mode=serial
+```
+
+```
 make firmware-connect
 ```
 Set a mode/capture - type 'help' and read instructions.

--- a/getting-started.md
+++ b/getting-started.md
@@ -370,8 +370,6 @@ Connect to lm32 softcore to send direct commands to the HDMI2USB such as
 changing resolution:
 ```
 hdmi2usb-mode-switch --mode=serial
-```
-```
 make firmware-connect
 ```
 Set a mode/capture - type 'help' and read instructions.


### PR DESCRIPTION
Connecting to lm32 softcore to send direct commands to the HDMI2USB , with direct command 

make firmware-connect 

gives following errors :

(LX P=opsis) nancy@nancy-Inspiron-5559:~/Desktop/HDMI2USB-litex-firmware$ make firmware-connect 
flterm --port=$(opsis-mode-switch --get-serial-dev)
WARNING:root:unbind-helper not found, will have to run as root!
Traceback (most recent call last):
  File "/home/nancy/Desktop/HDMI2USB-litex-firmware/build/conda/bin/opsis-mode-switch", line 11, in <module>
    sys.exit(main())
  File "/home/nancy/Desktop/HDMI2USB-litex-firmware/build/conda/lib/python3.6/site-packages/hdmi2usb/modeswitch/cli.py", line 392, in main
    print(board.tty()[0])
IndexError: list index out of range
[FLTERM] Starting...
Unable to open serial port: No such file or directory



To resolve it commands should be followed by :
hdmi2usb-mode-switch --mode=serial
make firmware-connect 
