### PR TITLE
firmware: Fix unused-var and type mismatch error in recent gcc (7+).

### DIFF
--- a/firmware/ci.c
+++ b/firmware/ci.c
@@ -710,7 +710,7 @@ static void video_mode_set(int mode)
 static void video_mode_secondary(char *str)
 {
 	char *token;
-	if((token = get_token(&str)) == '\0') return;
+	if((* (token = get_token(&str))) == '\0') return;
 
 	if(strcmp(token, "off") == 0) {
 		wprintf("Turning off secondary video mode\n");

--- a/firmware/pll.c
+++ b/firmware/pll.c
@@ -70,6 +70,8 @@ void pll_config_for_clock(int freq)
 	 * Reproducible both with DRP and initial reconfiguration.
 	 * Until this spartan6 weirdness is sorted out, just stick to 20x.
 	 */
+
+	(void) pll_config_10x[0]; // Dummy access to suppress to suppress -Werror=unused-const-variable.
 	program_data(pll_config_20x);
 #ifdef XILINX_SPARTAN6_WORKS_AMAZINGLY_WELL
 	if(freq < 2000)


### PR DESCRIPTION
When compiling the HDMI2USB firmware w/ recent gcc versions (I first noticed them in 7+), the build would error out in `pll.c` and `ci.c`. These are my proposed fixes.

The `pll.c` workaround `(void) pll_config10x[0];` is a no-op that makes gcc (and probably other C compilers) treat a variable as used. `-Werror=unused-const-variable` is enabled, and since it's a conditional compile _for now_ that determines whether `pll_config10x[0]` actually gets used, I think this is a better solution until the S6 issues get worked out.

The `ci.c` fix was attempting to compare a `char *` to a `char` literal, and I believe that to be a genuine bug. :)