### PR TITLE
Default Output 1 to Pattern.

### DIFF
--- a/firmware/config.c
+++ b/firmware/config.c
@@ -45,7 +45,7 @@ static const unsigned char config_defaults[CONFIG_KEY_COUNT] = {
 	true,  // Input1
 	// Output config
 	true, VIDEO_IN_DEFAULT, // Output 0
-	true, VIDEO_IN_DEFAULT, // Output 1
+	true, VIDEO_IN_PATTERN, // Output 1
 	// Encoder
 	true, VIDEO_IN_DEFAULT, 85, 25, true,
 	// Networking - MAC Address


### PR DESCRIPTION
This will help testing so I can see something working that does not rely on inputs or console.

output 0 is typically the projector, 
output 1 is confidence monitor - the presenter will see color bars until the systemd script fires and sets it to input1 