### PR TITLE
EDID: v_sync offset/width are 6-bit values

### DIFF
--- a/firmware/processor.c
+++ b/firmware/processor.c
@@ -267,7 +267,7 @@ static const struct video_timing video_modes[PROCESSOR_MODE_COUNT] = {
 
 		.v_active = 720,
 		.v_blanking = 30,
-		.v_sync_offset = 20,
+		.v_sync_offset = 5,
 		.v_sync_width = 5,
 
 		.flags = EDID_DIGITAL | EDID_HSYNC_POS | EDID_VSYNC_POS


### PR DESCRIPTION
Fix assumption that both h_sync and v_sync offset/width are 10-bit values, which resulted in the v_sync offset being sent as if it were 0; h_sync offset/width are 10-bit values, but v_sync offset/width
are 6-bit values.

`t->v_sync_offset_width_l` part of the change tested with `read-edid` in https://github.com/timvideos/HDMI2USB-litex-firmware/issues/478; `t->hv_sync_offset_width_h` part of the change only compiled.  (HackFest building logistics mean I can't test it with read-edid now, but by inspection the 4-bit/2-bit split seems more correct than the 8-bit shifts that were there before.)

`v_sync_offset` of 720p set back to recommended 5 lines value (from https://github.com/timvideos/HDMI2USB-litex-firmware/issues/478) now that it's actually being sent properly rather than as zero.

For a summary of the packing of the timing section of EDID bit see:

https://en.wikipedia.org/wiki/Extended_Display_Identification_Data#Detailed_Timing_Descriptor

Note that this did *not* make the Decimator accept the HDMI2USB output yet; so it's clearly not the only thing the Decimator didn't like :-(